### PR TITLE
Generate log at startup

### DIFF
--- a/examples/peerconnection/serverless/main.cc
+++ b/examples/peerconnection/serverless/main.cc
@@ -122,16 +122,23 @@ int main(int argc, char* argv[]) {
     exit(EINVAL);
   }
 
+  const auto json_file_path = argv[1];
+  if (!webrtc::ParseAlphaCCConfig(json_file_path)) {
+    std::cerr << "bad config file" << std::endl;
+    exit(EINVAL);
+  }
+
+  auto config = webrtc::GetAlphaCCConfig();
+
+  if (config->save_log_to_file) {
+    rtc::LogMessage::SetIfLogToFile(true);
+    rtc::LogMessage::SetLogFileName(config->log_output_path);
+  }
+
   webrtc::field_trial::InitFieldTrialsFromString(
       "WebRTC-KeepAbsSendTimeExtension/Enabled/");  //  Config for
                                                     //  hasAbsSendTimestamp in
                                                     //  RTP Header extension
-
-  const auto json_file_path = argv[1];
-  if (!webrtc::ParseAlphaCCConfig(json_file_path)) {
-    perror("bad config file");
-    exit(EINVAL);
-  }
 
 #ifdef WIN32
   rtc::WinsockInitializer win_sock_init;
@@ -149,13 +156,6 @@ int main(int argc, char* argv[]) {
   PeerConnectionClient client;
   rtc::scoped_refptr<Conductor> conductor(
       new rtc::RefCountedObject<Conductor>(&client, &wnd));
-
-  auto config = webrtc::GetAlphaCCConfig();
-
-  if (config->save_log_to_file) {
-    rtc::LogMessage::SetIfLogToFile(true);
-    rtc::LogMessage::SetLogFileName(config->log_output_path);
-  }
 
   if (config->is_receiver) {
     client.StartListen(config->listening_ip, config->listening_port);


### PR DESCRIPTION
- generate log at startup to avoid error in ONL platform
- Print error message to stderr directly instead of perror

This PR solved issue #33 